### PR TITLE
Update to use new PetscOptionsGetString interface

### DIFF
--- a/src/PetscMatrixBinary2Ascii.C
+++ b/src/PetscMatrixBinary2Ascii.C
@@ -29,7 +29,7 @@ int main( int argc, char **argv ) {
     ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size);CHKERRQ(ierr);        
     
     char buf[MAX_STRING];
-    ierr = PetscOptionsGetString(NULL,"-i",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-i",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify input matrix on the command line with switch -i.\n");
@@ -38,7 +38,7 @@ int main( int argc, char **argv ) {
     PetscPrintf(PETSC_COMM_WORLD,"Input file: %s\n",buf);
     in_mat.assign(buf);
     
-    ierr = PetscOptionsGetString(NULL,"-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify output matrix on the command line with switch -o.\n");
@@ -47,7 +47,7 @@ int main( int argc, char **argv ) {
     PetscPrintf(PETSC_COMM_WORLD,"Output file: %s\n",buf);
     out_mat.assign(buf);
                 
-    ierr = PetscOptionsGetString(NULL,"-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	is_ascii = PETSC_FALSE;
@@ -65,7 +65,7 @@ int main( int argc, char **argv ) {
       }
       
     use_complex = PETSC_FALSE;
-    ierr = PetscOptionsGetString(NULL,"-complex",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-complex",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_TRUE) 
       {
 	if ( strcmp(buf,"false") == 0 ) 
@@ -80,7 +80,7 @@ int main( int argc, char **argv ) {
       }
       
     PetscTruth use_compact = PETSC_FALSE;
-    ierr = PetscOptionsGetString(NULL,"-compact",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-compact",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_TRUE) 
       {
 	if ( strcmp(buf,"false") == 0 ) 

--- a/src/PetscSumVectors.C
+++ b/src/PetscSumVectors.C
@@ -36,7 +36,7 @@ int main( int argc, char **argv ) {
     
     
     char buf[MAX_STRING];
-    ierr = PetscOptionsGetString(NULL,"-vecs",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL, NULL, "-vecs",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify file which lists vectors and weights with -vecs option.\n");
@@ -46,7 +46,7 @@ int main( int argc, char **argv ) {
     string vecs_file;
     vecs_file.assign(buf);
     
-    ierr = PetscOptionsGetString(NULL,"-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL, NULL, "-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify output vector on the command line with switch -o.\n");
@@ -56,7 +56,7 @@ int main( int argc, char **argv ) {
     string out_vec;
     out_vec.assign(buf);
                 
-    ierr = PetscOptionsGetString(NULL,"-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL, NULL, "-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE ) 
       {
 	is_ascii = PETSC_FALSE;
@@ -73,7 +73,7 @@ int main( int argc, char **argv ) {
 	  }
       }
           
-    ierr = PetscOptionsGetString(NULL,"-overlap_vec",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL, NULL, "-overlap_vec",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     string overlap_vec_filename;
     bool use_overlap = false;
     if ( flg == PETSC_TRUE) 

--- a/src/PetscVectorBinary2Ascii.C
+++ b/src/PetscVectorBinary2Ascii.C
@@ -29,7 +29,7 @@ int main( int argc, char **argv ) {
     ierr = MPI_Comm_size(PETSC_COMM_WORLD, &size);CHKERRQ(ierr);        
     
     char buf[MAX_STRING];
-    ierr = PetscOptionsGetString(NULL,"-i",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-i",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify input vector on the command line with switch -i.\n");
@@ -38,7 +38,7 @@ int main( int argc, char **argv ) {
     PetscPrintf(PETSC_COMM_WORLD,"Input file: %s\n",buf);
     in_vec.assign(buf);
     
-    ierr = PetscOptionsGetString(NULL,"-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-o",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	PetscPrintf(PETSC_COMM_WORLD,"Must specify output vector on the command line with switch -o.\n");
@@ -47,7 +47,7 @@ int main( int argc, char **argv ) {
     PetscPrintf(PETSC_COMM_WORLD,"Output file: %s\n",buf);
     out_vec.assign(buf);
                 
-    ierr = PetscOptionsGetString(NULL,"-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-ascii",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_FALSE) 
       {
 	is_ascii = PETSC_FALSE;
@@ -65,7 +65,7 @@ int main( int argc, char **argv ) {
       }
       
     use_complex = PETSC_FALSE;
-    ierr = PetscOptionsGetString(NULL,"-complex",buf,MAX_STRING,&flg);CHKERRQ(ierr);
+    ierr = PetscOptionsGetString(NULL,NULL,"-complex",buf,MAX_STRING,&flg);CHKERRQ(ierr);
     if ( flg == PETSC_TRUE) 
       {
 	if ( strcmp(buf,"false") == 0 ) 

--- a/src/utils.C
+++ b/src/utils.C
@@ -123,7 +123,7 @@ int parse_main_input_file(struct parameter_struct *parameters) {
 	PetscTruth flg;
 
 	//Moving to new input mechanism with just one xml input file specifying all parameters
-	ierr = PetscOptionsGetString(NULL,"-input",parameters->input_file,MAX_STRING,&flg);CHKERRQ(ierr);
+	ierr = PetscOptionsGetString(NULL, NULL, "-input",parameters->input_file,MAX_STRING,&flg);CHKERRQ(ierr);
 	if ( flg == PETSC_FALSE) {
 	  PetscPrintf(PETSC_COMM_WORLD, "No input file specified exiting.\n");
 	  return 1;


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #1

## Description
The usage of the PetscOptionsGetString has been updated to take an additional argument corresponding to a character to use for input options. This is causing a build error in the current version which does not have a value for this argument.